### PR TITLE
Improve search reliability for Cyrillic queries

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -652,10 +652,6 @@
                 </div>
             </form>
 
-            {% if translated_query and translated_query != query %}
-            <div class="translation-note">Поиск выполняется по переводу: «{{ translated_query }}»</div>
-            {% endif %}
-
             <div class="summary-bar">
                 <span class="stat-chip"><strong>{{ matches }}</strong> материалов из {{ total }}</span>
                 {% if query %}


### PR DESCRIPTION
## Summary
- add Cyrillic to Latin transliteration helpers and use them to build token groups
- update the search index to accept token variants and drop the fragile runtime translation logic
- remove the translation warning banner from the UI since the new search no longer relies on it

## Testing
- python -m py_compile app.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918f344fb74832cbf40f902dac867f7)