### PR TITLE
Fix mobile action buttons layout

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -615,11 +615,14 @@
             }
 
             form.controls .control-actions {
+                flex-direction: column;
                 justify-content: stretch;
+                align-items: stretch;
             }
 
             form.controls button {
-                flex: 1 1 100%;
+                flex: 1 1 auto;
+                width: 100%;
             }
 
             .summary-bar {


### PR DESCRIPTION
## Summary
- stack action buttons vertically on small viewports to keep them inside the form container
- ensure mobile buttons stretch to full width without overflowing

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e39675e60832c80dff6081487a4ed)