### PR TITLE
Refine mobile buttons sizing

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -101,6 +101,7 @@
                 "search"
                 "toggles"
                 "actions";
+            grid-template-columns: minmax(0, 1fr);
             background: var(--glass);
             border-radius: var(--radius-lg);
             padding: clamp(20px, 4vw, 28px);
@@ -211,6 +212,8 @@
             flex-wrap: wrap;
             gap: 12px;
             justify-content: flex-start;
+            width: 100%;
+            min-width: 0;
         }
 
         form.controls button {
@@ -225,6 +228,8 @@
             color: #fff;
             box-shadow: 0 18px 30px -24px rgba(233, 137, 115, 0.9);
             transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
+            max-width: 100%;
+            min-width: 0;
         }
 
         form.controls button:hover {
@@ -615,11 +620,15 @@
             }
 
             form.controls .control-actions {
+                flex-direction: column;
                 justify-content: stretch;
+                align-items: stretch;
             }
 
             form.controls button {
-                flex: 1 1 100%;
+                flex: 1 1 auto;
+                padding: 12px 20px;
+                width: 100%;
             }
 
             .summary-bar {


### PR DESCRIPTION
## Summary
- ensure the controls grid uses a minmax column so action buttons cannot overflow on small screens
- make action buttons respect container width and reduce mobile padding for better fit

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e39675e60832c80dff6081487a4ed)